### PR TITLE
Pin clap version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,5 @@ serde_yaml = "0.8"
 linked-hash-map = { version = "0.5.3", features = ["serde_impl"]}
 chrono = { version = "0.4", features = ["serde"] }
 regex = "1"
-clap = "3.0.0-beta.1"
+clap = "= 3.0.0-beta.1"
 simple_logger = "1.6.0"


### PR DESCRIPTION
Fix error:

```
#9 199.1 error[E0599]: no method named `multiple` found for struct `Arg` in the current scope
#9 199.1   --> /root/.cargo/registry/src/github.com-1ecc6299db9ec823/ysv-0.1.6/src/main.rs:15:23
#9 199.1    |
#9 199.1 15 |         (@arg INPUT: +multiple "Sets the input CSV file(s) to read from")
#9 199.1    |                       ^^^^^^^^ method not found in `Arg<'_>`
```