### PR TITLE
clap derive fails compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,10 +517,11 @@ dependencies = [
 
 [[package]]
 name = "ysv"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "chrono",
  "clap",
+ "clap_derive",
  "crossbeam-channel",
  "csv",
  "linked-hash-map",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ysv"
-version = "0.1.10"
+version = "0.1.11"
 authors = ["Anatoly Scherbakov <altaisoft@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -27,5 +27,7 @@ linked-hash-map = { version = "0.5.3", features = ["serde_impl"]}
 chrono = { version = "0.4", features = ["serde"] }
 regex = "1"
 clap = "= 3.0.0-beta.1"
+clap_derive = "= 3.0.0-beta.4"
+
 simple_logger = "1.6.0"
 crossbeam-channel = "^0.5.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use ysv::{run, LogFormat};
 /// Parse command line arguments and start the application.
 fn main() -> Result<(), String> {
     let matches = clap_app!(ysv =>
-        (version: "0.1.10\n")
+        (version: "0.1.11\n")
         (author: "Anatoly I. Scherbakov <altaisoft@gmail.com>")
         (about: "YAML-driven CSV formatter")
         (@arg LOG_FORMAT: -f --log-format +takes_value "Log format: 'plain' (default) or 'json'")


### PR DESCRIPTION
- Use crossbeam and restrict queue size
- Use `crossbeam` with a hard-coded queue size
- Remove unnecessary/commented code, and bump version
- Pin version of `clap-derive`
